### PR TITLE
Spelling, grammar, and picture swap to a different section

### DIFF
--- a/css/freelancer.css
+++ b/css/freelancer.css
@@ -603,14 +603,19 @@ hr.star-light.transparent:after {
 }
 
 .about-pic-2 {
-    margin-top: 30px;
-    width: 150px;
+    margin: 30px 0;
+    width: 170px;
     border-radius: 5px;
 }
 
 .bordered-picture {
     padding: 1px;
     border: 1px solid #F7F7F7;
+}
+
+.bordered-picture-2 {
+    padding: 1px;
+    border: 1px solid #18bc9c;
 }
 
 footer p {

--- a/index.html
+++ b/index.html
@@ -278,7 +278,7 @@
                     </form> -->
                     <div class="row">
                         <div class="col-lg-8 col-lg-offset-2 text-center">
-                            <img class="about-pic-2 bordered-picture" src="img/filipek-face-about.png"/>
+                            <img class="about-pic-2 bordered-picture-2" src="img/filipek-face-about.png"/>
                         </div>
                     </div>
                     <br/>

--- a/index.html
+++ b/index.html
@@ -116,11 +116,11 @@
                     <p align="center">Along the way, he earned an MA in Literature and began writing two young-adult novels.  He is a lifelong athlete, an avid reader and writer, a true scholar of the personal essay, a fierce board gamer (especially when matched against his wife), and a member of a large and happy family.</p>
                 </div>
             </div>
-            <div class="row">
+            <!-- <div class="row">
                 <div class="col-lg-8 col-lg-offset-2 text-center">
                     <img class="about-pic-2 bordered-picture" src="img/filipek-face-about.png"/>
                 </div>
-            </div>
+            </div> -->
             <div class="row">
                 <div class="col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 about-text-1">
                     <p align="center">While Cole is a fantastic SAT coach and a great math tutor, his true passion lies with the personal statement.  Twenty years after writing his own personal statement (which he thinks got him into Columbia), Cole still devotes the same energy and attention to detail to each and every essay that he works with. 
@@ -276,6 +276,12 @@
                             </div>
                         </div>
                     </form> -->
+                    <div class="row">
+                        <div class="col-lg-8 col-lg-offset-2 text-center">
+                            <img class="about-pic-2 bordered-picture" src="img/filipek-face-about.png"/>
+                        </div>
+                    </div>
+                    <br/>
                     <div class="row pull-center">
                         <div class="col-lg-6 contact-email">
                             <h3>Email:</h3>
@@ -504,7 +510,7 @@
 
                                 <div class="alternating-container">
                                     <ul class="modal-text">
-                                        <li>"He used wisdom and patience to help Anashe's essay  I really appreciated Cole's focus on keeping the writing positive."
+                                        <li>"He used wisdom and patience to help Anashe's essay.  I really appreciated Cole's focus on keeping the writing positive."
                                         </li>
                                         <li class="client-name">--Margaret Barton, mother of Anashe Barton, UC Berkeley, Class of 2014
                                         </li>
@@ -514,7 +520,7 @@
                                 <ul class="modal-text">
 
                                     <div class="alternating-container">
-                                        <li>"Mays improved a lot duplicationring his  time with Cole.  We are very  thankful for Cole's hard work!"
+                                        <li>"Mays improved a lot during his  time with Cole.  We are very  thankful for Cole's hard work!"
                                         </li>
                                         <li class="client-name">--Erin Gaffey, mother of Mays Washington, Bishop O'Dowd, Class of 2019
                                         </li>
@@ -659,15 +665,6 @@
                                     </li>
                                     <li>
                                         A: No. However, Cole guarantees that you or your loved one will produce an excellent essay.
-                                    </li>
-                                </div>
-
-                                <div class="alternating-container">
-                                    <li>
-                                        Q: I'm still not convinced.
-                                    </li>
-                                    <li>
-                                        A: The first consultation comes with homework!  Lots of homework!
                                     </li>
                                 </div>
 


### PR DESCRIPTION
Fix spelling and grammar mistakes in FAQ and Past Clients. Move about-pic-2 to Contact section.
